### PR TITLE
Prevent invalid star ratings if cursor is close to left/right edge of star array

### DIFF
--- a/js/star-rating.js
+++ b/js/star-rating.js
@@ -360,6 +360,7 @@
             else if (val > self.max) {
                 val = self.max;
             }
+            val = Math.max(Math.min(val,self.max), self.min);
             val = applyPrecision(parseFloat(val), precision);
             if (self.rtl) {
                 val = self.max - val;


### PR DESCRIPTION
I had problems with the star-rating plugin in my setup, because I could set an invalid star rating if I managed to click the outermost pixel (don't ask me how I managed to do that :)):

![star-rating-bug](https://cloud.githubusercontent.com/assets/2988903/5037198/11d613fa-6b86-11e4-8251-352c88c85667.png)

So for example, I set the rating to 3 stars and I was able to set the value to 4. This is how I configured the plugin in my project:

`$('.rb-rating').rating({'showCaption':true, 'stars':'3', 'min':'0', 'max':'3', 'step':'1', 'size':'xs', 'starCaptions': {0:'status:nix', 1:'status:wackelt', 2:'status:geht', 3:'status:laeuft'}});`

I tried to reproduce the error with your example HTML, but I couldn't do it. So I decided to create my pull request anyway, because this definately fixes my problem and maybe this problem pops up at some point in the future.

Cheers
Stefan
