### PR TITLE
Do not render [-] if read only

### DIFF
--- a/js/star-rating.js
+++ b/js/star-rating.js
@@ -270,7 +270,7 @@
                     self.$container.append(caption);
                 }
             }
-            if (isEmpty(self.$clear)) {
+            if (!self.readonlyis && Empty(self.$clear)) {
                 if (self.rtl) {
                     self.$container.append(clear);
                 }


### PR DESCRIPTION
The - button is useless and it feel natural not to have it when it's set to readonly.

By the way the minified version does not work in the sense that the stars do not appear, I'm guessing the minifier changes the chars format.