### PR TITLE
Added "main" key into NPM package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "type": "git", 
         "url": "https://github.com/kartik-v/bootstrap-star-rating.git"
     },
+    "main": "js/star-rating.min.js",
     "keywords": [
         "bootstrap",
         "star",


### PR DESCRIPTION
By adding a main key to the package.json, Webpack is able to pick up the entry point and able to import the library simply by:

```import 'bootstrap-star-rating';```