### PR TITLE
add static attribute configuration for "displayOnly" and "showCaption"

### DIFF
--- a/js/star-rating.js
+++ b/js/star-rating.js
@@ -207,6 +207,8 @@
             self._setDefault('min', self._parseAttr('min', options));
             self._setDefault('max', self._parseAttr('max', options));
             self._setDefault('step', self._parseAttr('step', options));
+            self._setDefault('displayOnly', self._parseAttr('display-only', options));
+            self._setDefault('showCaption', self._parseAttr('show-caption', options));
             if (isNaN(self.min) || isEmpty(self.min)) {
                 self.min = DEFAULT_MIN;
             }


### PR DESCRIPTION
Currently, there is no way to specify in the attributes for an input tag whether a star-rating field should be specified as "displayOnly" or "showCaption", as per [the demo documentation here](http://plugins.krajee.com/star-rating-demo-basic-usage).

This simple commit adds that functionality by adding support for `data-display-only` and `data-show-caption` attributes.  This allows for display only star rating fields to be described entirely in HTML without explicit post-render formatting (except that done automatically by star-rating.js).

Let me know if there is any additional build / cleaning stuff I need to do before putting this through.  I think it will be a very nice thing to have in the project.