### PR TITLE
Allow autodetecting displayOnly from HTML markup

### DIFF
--- a/js/star-rating.js
+++ b/js/star-rating.js
@@ -243,6 +243,7 @@
             var self = this, $el = self.$element, opts = self.options;
             self.disabled = opts.disabled === undefined ? $el.attr('disabled') || false : opts.disabled;
             self.readonly = opts.readonly === undefined ? $el.attr('readonly') || false : opts.readonly;
+            self.displayOnly = $el.data('displayonly') ? true : self.displayOnly;
             self.inactive = (self.disabled || self.readonly);
             $el.attr({disabled: self.disabled, readonly: self.readonly});
         },


### PR DESCRIPTION
Currently there is no (as far as I could see) way to set displayOnly without manually initializing the plugin from JS.  This PR allows using ```data-displayonly="true"``` in HTML markup to automatically set displayOnly mode.