### PR TITLE
Don't refer to minified files in Bower main metadata

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,8 @@
     ],
     "description": "A simple yet powerful JQuery star rating plugin for Bootstrap.",
     "main": [
-        "./css/star-rating.min.css",
-        "./js/star-rating.min.js"
+        "./css/star-rating.css",
+        "./js/star-rating.js"
     ],
     "keywords": [
         "bootstrap",


### PR DESCRIPTION
This is to appease the bower warning about including minified files in the metadata, as per this [spec](https://github.com/bower/spec/blob/master/json.md#main)