### PR TITLE
Update star-rating.js

### DIFF
--- a/js/star-rating.js
+++ b/js/star-rating.js
@@ -167,6 +167,12 @@
             self._renderCaption();
             self._renderClear();
             self._initHighlight();
+
+            if (self.addCaptionAsTitle !=undefined && self.addCaptionAsTitle) {
+                var caption = self.fetchCaption(self.$element.val());
+                self.$rating.attr('title', $(caption).text());    
+            }
+            
             $container.append($el);
             if (self.rtl) {
                 w = Math.max(self.$emptyStars.outerWidth(), self.$filledStars.outerWidth());
@@ -184,6 +190,7 @@
                 self.$caption.html(content);
             }
         },
+
         _renderCaption: function () {
             var self = this, val = self.$element.val(), html, $cap = self.captionElement ? $(self.captionElement) : '';
             if (!self.showCaption) {
@@ -253,7 +260,9 @@
             if (self.displayOnly) {
                 self.inactive = true;
                 self.showClear = false;
-                self.showCaption = false;
+                if (self.addCaptionAsTitle === undefined) {
+                    self.addCaptionAsTitle = true;    
+                }
             }
             self._generateRating();
             self._initEvents();
@@ -541,6 +550,7 @@
         rtl: false,
         showClear: true,
         showCaption: true,
+        addCaptionAsTitle: undefined,
         starCaptionClasses: {
             0.5: 'label label-danger badge-danger',
             1: 'label label-danger badge-danger',


### PR DESCRIPTION


## Scope
This pull request includes a

- [x] Bug fix
- [x] New feature

## Changes
The following changes were made
- a new Parameter addCaptionAsTitle was added
Which is set to true in displayOnly Mode but only when it isn't manually set.
So it is still possible to disable it.  

When addCaptionAsTitle  = true the caption "content" is set as the title html attribute to the stars containing div.
So you would get the correct value on hover


I just get the caption content by using the text() function.
But of course an additional function which only returns the caption text like fetchCaptionValue would also be possible and maybe even better.


- The parameter showCaption isn't disabled in displayOnly  = true automatically any more. 
So the caption could be rendered in displayOnly  mode.
If the caption shouldn't be shown it has to be disabled manually.


## Related Issues
https://github.com/kartik-v/bootstrap-star-rating/issues/177